### PR TITLE
fix(roster): stage native Claude team files from session pods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ Both registries support a subdirectory via `rootPath` / `catalogPrefix` / `repoP
 
 ### Member placement (Machines)
 
-Workspace + landing **Machine assignment** pins each roster replica to `local` or an SSH profile. Placement writes `roster.overrides.replicas` and host targets; mixed session create omits unpinned instances from `AppSession.members` and TeamBus. Prefer **`sessionRosterMembers(session, team)`** (in `app_session.dart`) for UI / presence / materialize — do **not** re-expand stale `TeamMemberConfig.replicas` from an in-memory team after placement saves.
+Workspace + landing **Machine assignment** pins each roster replica to `local` or an SSH profile. Placement writes `roster.overrides.replicas` and host targets; mixed session create omits unpinned instances from `AppSession.members` and TeamBus. Prefer **`sessionRosterMembers(session, team)`** (in `app_session.dart`) for UI / presence / materialize — do **not** re-expand stale `TeamMemberConfig.replicas` from an in-memory team after placement saves. Native Claude roster writers (`teams/.../config.json`, inboxes) must use `cliTeamRosterMembers(session, team)` when a session exists, or `runtimeRosterMembers(team)` for preview — never raw `team.members`.
 
 ### Team session CLI identity
 

--- a/client/lib/models/app_session.dart
+++ b/client/lib/models/app_session.dart
@@ -52,6 +52,17 @@ List<TeamMemberConfig> sessionRosterMembers(
   return out;
 }
 
+/// Pod list for Claude / native CLI roster writers (`config.json`, inboxes).
+///
+/// Same members as [sessionRosterMembers] today. Call sites that stage CLI
+/// team files must use this (or [runtimeRosterMembers] without a session),
+/// never raw [TeamProfile.members].
+List<TeamMemberConfig> cliTeamRosterMembers(
+  AppSession session,
+  TeamProfile team,
+) =>
+    sessionRosterMembers(session, team);
+
 TeamMemberConfig? _sessionBindingMemberType(
   SessionMemberBinding binding,
   Map<String, TeamMemberConfig> typesById,

--- a/client/lib/models/member_instance.dart
+++ b/client/lib/models/member_instance.dart
@@ -30,13 +30,23 @@ class MemberInstance {
   /// Runtime workspaceion: a [TeamMemberConfig] with `id = instanceId` and the
   /// type id seeded as a capability so [TaskRouter] routes the pool by type
   /// (and the pod by its own id, via the id-as-capability rule).
-  TeamMemberConfig toMemberConfig() => type.copyWith(
-    id: instanceId,
-    name: displayName,
-    capabilities: {type.id, ...type.capabilities},
-    // A workspaceion is a single concrete pod — never itself re-expandable.
-    replicas: 1,
-  );
+  TeamMemberConfig toMemberConfig() {
+    final seededAgentType = () {
+      final explicit = type.agentType.trim();
+      if (explicit.isNotEmpty) return explicit;
+      final fromAgent = type.agent.trim();
+      if (fromAgent.isNotEmpty) return fromAgent;
+      return type.id;
+    }();
+    return type.copyWith(
+      id: instanceId,
+      name: displayName,
+      agentType: seededAgentType,
+      capabilities: {type.id, ...type.capabilities},
+      // A workspaceion is a single concrete pod — never itself re-expandable.
+      replicas: 1,
+    );
+  }
 }
 
 /// The single Deployment→Pod fan-out. The team-lead is always a singleton; any

--- a/client/lib/models/member_instance.dart
+++ b/client/lib/models/member_instance.dart
@@ -4,7 +4,7 @@ import 'team_config.dart';
 /// A runtime instance (Pod) of a member [type] (Deployment). Holds no copy of
 /// the spec — it resolves prompt/playbook/model/cli through [type]. The single
 /// Deployment→Pod fan-out is [expandTeamRoster]; the runtime consumes the
-/// [toMemberConfig] workspaceion via [runtimeRosterMembers].
+/// [toMemberConfig] projection via [runtimeRosterMembers].
 class MemberInstance {
   const MemberInstance({
     required this.type,
@@ -27,7 +27,7 @@ class MemberInstance {
   String get displayName =>
       replicas <= 1 ? type.name : '${type.name} #$ordinal';
 
-  /// Runtime workspaceion: a [TeamMemberConfig] with `id = instanceId` and the
+  /// Runtime projection: a [TeamMemberConfig] with `id = instanceId` and the
   /// type id seeded as a capability so [TaskRouter] routes the pool by type
   /// (and the pod by its own id, via the id-as-capability rule).
   TeamMemberConfig toMemberConfig() => type.copyWith(
@@ -41,7 +41,7 @@ class MemberInstance {
       agentType: type.agentType,
     ),
     capabilities: {type.id, ...type.capabilities},
-    // A workspaceion is a single concrete pod — never itself re-expandable.
+    // A projection is a single concrete pod — never itself re-expandable.
     replicas: 1,
   );
 }
@@ -64,7 +64,7 @@ List<MemberInstance> expandTeamRoster(List<TeamMemberConfig> members) {
   return out;
 }
 
-/// Instance workspaceions the launch/bus layers iterate in place of
+/// Instance projections the launch/bus layers iterate in place of
 /// `team.members`.
 List<TeamMemberConfig> runtimeRosterMembers(TeamProfile team) => [
   for (final inst in expandTeamRoster(team.members)) inst.toMemberConfig(),

--- a/client/lib/models/member_instance.dart
+++ b/client/lib/models/member_instance.dart
@@ -30,23 +30,20 @@ class MemberInstance {
   /// Runtime workspaceion: a [TeamMemberConfig] with `id = instanceId` and the
   /// type id seeded as a capability so [TaskRouter] routes the pool by type
   /// (and the pod by its own id, via the id-as-capability rule).
-  TeamMemberConfig toMemberConfig() {
-    final seededAgentType = () {
-      final explicit = type.agentType.trim();
-      if (explicit.isNotEmpty) return explicit;
-      final fromAgent = type.agent.trim();
-      if (fromAgent.isNotEmpty) return fromAgent;
-      return type.id;
-    }();
-    return type.copyWith(
-      id: instanceId,
-      name: displayName,
-      agentType: seededAgentType,
-      capabilities: {type.id, ...type.capabilities},
-      // A workspaceion is a single concrete pod — never itself re-expandable.
-      replicas: 1,
-    );
-  }
+  TeamMemberConfig toMemberConfig() => type.copyWith(
+    id: instanceId,
+    name: displayName,
+    // Seed role id (not pod id) so Claude roster agentType stays `developer`
+    // when replicas expand to `developer-0`.
+    agentType: TeamMemberNaming.resolveAgentType(
+      memberId: type.id,
+      agent: type.agent,
+      agentType: type.agentType,
+    ),
+    capabilities: {type.id, ...type.capabilities},
+    // A workspaceion is a single concrete pod — never itself re-expandable.
+    replicas: 1,
+  );
 }
 
 /// The single Deployment→Pod fan-out. The team-lead is always a singleton; any

--- a/client/lib/services/launch/session_connect_orchestrator.dart
+++ b/client/lib/services/launch/session_connect_orchestrator.dart
@@ -261,7 +261,7 @@ class SessionConnectOrchestrator {
         teamId: teamId,
         cliTeamName: runtimeTeamId,
         cli: cli,
-        members: team.members,
+        members: cliTeamRosterMembers(session, team),
         member: member,
         workingDirectory: workingDirectory,
         additionalDirectories: additionalDirectories,

--- a/client/lib/services/session/session_lifecycle_service.dart
+++ b/client/lib/services/session/session_lifecycle_service.dart
@@ -8,6 +8,7 @@ import '../../models/cli_preset.dart';
 import '../../models/session_member_binding.dart';
 import '../../models/skill.dart';
 import '../../models/team_config.dart';
+import '../../models/member_instance.dart';
 import '../../models/launch_profile.dart';
 import '../../repositories/cli_presets_repository.dart';
 import '../../repositories/launch_profile_repository.dart';
@@ -413,7 +414,7 @@ class SessionLifecycleService {
               globalPresets: _loadPresets?.call() ?? const [],
             )
           : team.cli,
-      members: team.members,
+      members: runtimeRosterMembers(team),
       member: launchMember.isValid ? launchMember : null,
       workingDirectory: workingDirectory.isNotEmpty
           ? workingDirectory
@@ -841,7 +842,7 @@ class SessionLifecycleService {
       teamId: teamId,
       cliTeamName: runtimeTeamId,
       cli: launchCli,
-      members: team.members,
+      members: cliTeamRosterMembers(session, team),
       member: member,
       workingDirectory: memberDirs.workingDirectory.isNotEmpty
           ? memberDirs.workingDirectory

--- a/client/test/models/member_instance_test.dart
+++ b/client/test/models/member_instance_test.dart
@@ -59,6 +59,38 @@ void main() {
     expect(insts.single.instanceId, 'team-lead');
   });
 
+  test('workspaceion seeds agentType from type id when empty', () {
+    final cfg = expandTeamRoster(const [
+      TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+    ]).first.toMemberConfig();
+    expect(cfg.id, 'developer-0');
+    expect(cfg.agentType, 'developer');
+  });
+
+  test('workspaceion preserves explicit type.agentType', () {
+    final cfg = expandTeamRoster(const [
+      TeamMemberConfig(
+        id: 'developer',
+        name: 'Developer',
+        replicas: 2,
+        agentType: 'implementer',
+      ),
+    ]).first.toMemberConfig();
+    expect(cfg.agentType, 'implementer');
+  });
+
+  test('workspaceion seeds agentType from type.agent when agentType empty', () {
+    final cfg = expandTeamRoster(const [
+      TeamMemberConfig(
+        id: 'developer',
+        name: 'Developer',
+        replicas: 2,
+        agent: 'coder',
+      ),
+    ]).first.toMemberConfig();
+    expect(cfg.agentType, 'coder');
+  });
+
   test('workspaceion seeds the type id as a capability', () {
     final inst = expandTeamRoster(const [
       TeamMemberConfig(

--- a/client/test/models/member_instance_test.dart
+++ b/client/test/models/member_instance_test.dart
@@ -173,6 +173,57 @@ void main() {
     },
   );
 
+  test('cliTeamRosterMembers matches sessionRosterMembers', () {
+    final profile = team(const [
+      TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+      TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+      TeamMemberConfig(id: 'reviewer', name: 'Reviewer', replicas: 0),
+    ]);
+    final session = AppSession(
+      sessionId: 's1',
+      workspaceId: 'w1',
+      createdAt: 1,
+      members: const [
+        SessionMemberBinding(rosterMemberId: 'team-lead', taskId: 't0'),
+        SessionMemberBinding(
+          rosterMemberId: 'developer-0',
+          typeId: 'developer',
+          taskId: 't1',
+        ),
+        SessionMemberBinding(
+          rosterMemberId: 'developer-1',
+          typeId: 'developer',
+          taskId: 't2',
+        ),
+      ],
+    );
+    final cli = cliTeamRosterMembers(session, profile);
+    final ui = sessionRosterMembers(session, profile);
+    expect(cli.map((m) => m.id), ui.map((m) => m.id));
+    expect(cli.map((m) => m.id), ['team-lead', 'developer-0', 'developer-1']);
+    expect(cli.map((m) => m.agentType), ['team-lead', 'developer', 'developer']);
+  });
+
+  test('singleton replica keeps bare type id', () {
+    final profile = team(const [
+      TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+      TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 1),
+    ]);
+    final session = AppSession(
+      sessionId: 's1',
+      workspaceId: 'w1',
+      createdAt: 1,
+      members: const [
+        SessionMemberBinding(rosterMemberId: 'team-lead', taskId: 't0'),
+        SessionMemberBinding(rosterMemberId: 'developer', taskId: 't1'),
+      ],
+    );
+    expect(
+      cliTeamRosterMembers(session, profile).map((m) => m.id),
+      ['team-lead', 'developer'],
+    );
+  });
+
   test(
     'sessionRosterMembers infers type from numbered instance id without typeId',
     () {

--- a/client/test/models/member_instance_test.dart
+++ b/client/test/models/member_instance_test.dart
@@ -59,7 +59,7 @@ void main() {
     expect(insts.single.instanceId, 'team-lead');
   });
 
-  test('workspaceion seeds agentType from type id when empty', () {
+  test('projection seeds agentType from type id when empty', () {
     final cfg = expandTeamRoster(const [
       TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
     ]).first.toMemberConfig();
@@ -67,7 +67,7 @@ void main() {
     expect(cfg.agentType, 'developer');
   });
 
-  test('workspaceion preserves explicit type.agentType', () {
+  test('projection preserves explicit type.agentType', () {
     final cfg = expandTeamRoster(const [
       TeamMemberConfig(
         id: 'developer',
@@ -79,7 +79,7 @@ void main() {
     expect(cfg.agentType, 'implementer');
   });
 
-  test('workspaceion seeds agentType from type.agent when agentType empty', () {
+  test('projection seeds agentType from type.agent when agentType empty', () {
     final cfg = expandTeamRoster(const [
       TeamMemberConfig(
         id: 'developer',
@@ -91,7 +91,7 @@ void main() {
     expect(cfg.agentType, 'coder');
   });
 
-  test('workspaceion seeds the type id as a capability', () {
+  test('projection seeds the type id as a capability', () {
     final inst = expandTeamRoster(const [
       TeamMemberConfig(
         id: 'builder',
@@ -103,11 +103,11 @@ void main() {
     final cfg = inst.toMemberConfig();
     expect(cfg.id, 'builder-0');
     expect(cfg.capabilities, {'builder', 'rust'});
-    // a workspaceion is a single concrete pod, not itself re-expandable
+    // a projection is a single concrete pod, not itself re-expandable
     expect(cfg.replicas, 1);
   });
 
-  test('runtimeRosterMembers workspaces every instance', () {
+  test('runtimeRosterMembers projects every instance', () {
     final members = runtimeRosterMembers(
       team(const [
         TeamMemberConfig(id: 'team-lead', name: 'team-lead'),

--- a/client/test/services/session/session_lifecycle_service_test.dart
+++ b/client/test/services/session/session_lifecycle_service_test.dart
@@ -465,6 +465,111 @@ void main() {
     },
   );
 
+  test('prepareLaunch writes Claude roster pods not type names', () async {
+    const team = TeamProfile(
+      id: 'team-a',
+      name: 'Team A',
+      cli: CliTool.claude,
+      members: [
+        TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+        TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+        TeamMemberConfig(id: 'reviewer', name: 'Reviewer', replicas: 0),
+      ],
+    );
+    final session = _session(id: 'claude-roster-pods').copyWith(
+      cliTeamName: 'team-a-5',
+      members: const [
+        SessionMemberBinding(rosterMemberId: 'team-lead', taskId: 't0'),
+        SessionMemberBinding(
+          rosterMemberId: 'developer-0',
+          typeId: 'developer',
+          taskId: 't1',
+        ),
+        SessionMemberBinding(
+          rosterMemberId: 'developer-1',
+          typeId: 'developer',
+          taskId: 't2',
+        ),
+      ],
+    );
+
+    final plan = await service().prepareLaunch(
+      session: session,
+      team: team,
+      member: const TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+      memberBinding: const SessionMemberBinding(
+        rosterMemberId: 'team-lead',
+        taskId: 't0',
+      ),
+    );
+
+    final rosterDir = p.join(
+      plan.memberConfigDir,
+      'teams',
+      ClaudeTeamRosterService.safeClaudePathSegment(plan.cliTeamName),
+    );
+    final configPath = p.join(rosterDir, 'config.json');
+    expect(File(configPath).existsSync(), isTrue);
+    final decoded = jsonDecode(File(configPath).readAsStringSync()) as Map;
+    final names = (decoded['members'] as List)
+        .map((m) => (m as Map)['name'])
+        .toList();
+    expect(names, ['team-lead', 'developer-0', 'developer-1']);
+    expect(
+      File(p.join(rosterDir, 'inboxes', 'developer-0.json')).existsSync(),
+      isTrue,
+    );
+    expect(
+      File(p.join(rosterDir, 'inboxes', 'developer.json')).existsSync(),
+      isFalse,
+    );
+  });
+
+  test(
+    'prepareTeamLaunchEnvironment expands runtimeRosterMembers',
+    () async {
+      const team = TeamProfile(
+        id: 'team-a',
+        name: 'Team A',
+        cli: CliTool.claude,
+        members: [
+          TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+          TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+          TeamMemberConfig(id: 'reviewer', name: 'Reviewer', replicas: 0),
+        ],
+      );
+
+      await service().prepareTeamLaunchEnvironment(
+        team: team,
+        member: const TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+        workspaceId: _workspaceId,
+        sessionId: 'preview-session',
+        workingDirectory: '/work/workspace',
+      );
+
+      final rosterDir = p.join(
+        layout.sessionRuntimeToolDir(_workspaceId, 'preview-session', 'claude'),
+        'teams',
+        ClaudeTeamRosterService.safeClaudePathSegment('team-a'),
+      );
+      final configPath = p.join(rosterDir, 'config.json');
+      expect(File(configPath).existsSync(), isTrue);
+      final decoded = jsonDecode(File(configPath).readAsStringSync()) as Map;
+      final names = (decoded['members'] as List)
+          .map((m) => (m as Map)['name'])
+          .toList();
+      expect(names, ['team-lead', 'developer-0', 'developer-1']);
+      expect(
+        File(p.join(rosterDir, 'inboxes', 'developer-0.json')).existsSync(),
+        isTrue,
+      );
+      expect(
+        File(p.join(rosterDir, 'inboxes', 'developer.json')).existsSync(),
+        isFalse,
+      );
+    },
+  );
+
   test('destroyCliState removes the session runtime tree', () async {
     final sessionRoot = layout.workspace.sessionRuntimeDir(
       _workspaceId,

--- a/client/test/services/team/claude_team_roster_service_test.dart
+++ b/client/test/services/team/claude_team_roster_service_test.dart
@@ -1,8 +1,11 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:teampilot/models/member_instance.dart';
 import 'package:teampilot/models/team_config.dart';
+import 'package:teampilot/services/io/local_filesystem.dart';
 import 'package:teampilot/services/team/claude_team_roster_service.dart';
 import 'package:teampilot/utils/team/team_member_naming.dart';
-import 'package:teampilot/services/io/local_filesystem.dart';
 
 void main() {
   test('mergeConfig injects team-lead when missing from UI members', () {
@@ -59,5 +62,79 @@ void main() {
     final members = config['members'] as List;
     final dev = members.last as Map;
     expect(dev['isActive'], isTrue);
+  });
+
+  test('mergeConfig with pods writes pod names and role agentType', () {
+    final service = ClaudeTeamRosterService(fs: LocalFilesystem());
+    final pods = runtimeRosterMembers(
+      TeamProfile(
+        id: 'default-native-team',
+        name: 'Default',
+        members: [
+          TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+          TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+          TeamMemberConfig(id: 'reviewer', name: 'Reviewer', replicas: 0),
+        ],
+      ),
+    );
+    final config = service.mergeConfig(
+      cliTeamName: 'default-native-team-5',
+      members: pods,
+      cwd: '/workspace',
+      teammateMode: 'in-process',
+    );
+    final members = (config['members'] as List).cast<Map>();
+    expect(members.map((m) => m['name']), [
+      'team-lead',
+      'developer-0',
+      'developer-1',
+    ]);
+    expect(members.map((m) => m['agentId']), [
+      'team-lead',
+      'developer-0@default-native-team-5',
+      'developer-1@default-native-team-5',
+    ]);
+    final dev0 = members.firstWhere((m) => m['name'] == 'developer-0');
+    expect(dev0['agentType'], 'developer');
+  });
+
+  test('ensureInboxes creates pod files not type file', () async {
+    final root = Directory.systemTemp.createTempSync('claude-roster-');
+    addTearDown(() => root.deleteSync(recursive: true));
+    final fs = LocalFilesystem();
+    final service = ClaudeTeamRosterService(fs: fs);
+    final rosterDir = fs.pathContext.join(root.path, 'teams', 't');
+    final pods = runtimeRosterMembers(
+      TeamProfile(
+        id: 't',
+        name: 'T',
+        members: [
+          TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+          TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+        ],
+      ),
+    );
+    await service.ensureInboxes(rosterDir: rosterDir, members: pods);
+    expect(
+      await fs
+          .stat(fs.pathContext.join(rosterDir, 'inboxes', 'developer-0.json'))
+          .then((s) => s.exists),
+      isTrue,
+    );
+    expect(
+      File(fs.pathContext.join(rosterDir, 'inboxes', 'developer-0.json'))
+          .existsSync(),
+      isTrue,
+    );
+    expect(
+      File(fs.pathContext.join(rosterDir, 'inboxes', 'developer-1.json'))
+          .existsSync(),
+      isTrue,
+    );
+    expect(
+      File(fs.pathContext.join(rosterDir, 'inboxes', 'developer.json'))
+          .existsSync(),
+      isFalse,
+    );
   });
 }

--- a/docs/superpowers/plans/2026-08-03-native-cli-roster-pods.md
+++ b/docs/superpowers/plans/2026-08-03-native-cli-roster-pods.md
@@ -1,0 +1,500 @@
+# Native CLI roster = session pods Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Claude native-team `config.json` / inboxes / `--agent-id` use session pod ids (`developer-0`) instead of type ids (`developer`), so SendMessage lands in the inbox the running shell polls.
+
+**Architecture:** Seed role `agentType` on `MemberInstance.toMemberConfig`. Add `cliTeamRosterMembers` as a thin alias of `sessionRosterMembers`. Point session launch staging at pods; point no-session preview staging at `runtimeRosterMembers`. No SendMessage aliases, no idle wake-up.
+
+**Tech Stack:** Flutter / Dart, existing `ClaudeTeamRosterService`, `flutter_test`.
+
+**Spec:** `docs/superpowers/specs/2026-08-03-native-cli-roster-pods-design.md`
+
+---
+
+## File map
+
+| File | Responsibility |
+|------|----------------|
+| `client/lib/models/member_instance.dart` | Seed `agentType` on pod `toMemberConfig` |
+| `client/lib/models/app_session.dart` | Add `cliTeamRosterMembers` → `sessionRosterMembers` |
+| `client/lib/services/launch/session_connect_orchestrator.dart` | `stageTeamLaunch(members: cliTeamRosterMembers(...))` |
+| `client/lib/services/session/session_lifecycle_service.dart` | Live seat: pods; preview env: `runtimeRosterMembers` |
+| `AGENTS.md` | Document CLI roster hard rule |
+| `client/test/models/member_instance_test.dart` | agentType seed + resolver cases |
+| `client/test/services/team/claude_team_roster_service_test.dart` | merge/inbox with pods |
+| Staging test (extend existing prepare/stage test or small focused test) | Disk `config.json` + `inboxes/developer-0.json` |
+
+**Out of scope (do not touch):** type-name aliases, idle doorbell, `teammateMode`, mixed TeamBus, placement UI.
+
+---
+
+### Task 1: Seed `agentType` on pod expansion (TDD)
+
+**Files:**
+- Modify: `client/lib/models/member_instance.dart` (`toMemberConfig`)
+- Modify: `client/test/models/member_instance_test.dart`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `member_instance_test.dart`:
+
+```dart
+test('workspaceion seeds agentType from type id when empty', () {
+  final cfg = expandTeamRoster(const [
+    TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+  ]).first.toMemberConfig();
+  expect(cfg.id, 'developer-0');
+  expect(cfg.agentType, 'developer');
+});
+
+test('workspaceion preserves explicit type.agentType', () {
+  final cfg = expandTeamRoster(const [
+    TeamMemberConfig(
+      id: 'developer',
+      name: 'Developer',
+      replicas: 2,
+      agentType: 'implementer',
+    ),
+  ]).first.toMemberConfig();
+  expect(cfg.agentType, 'implementer');
+});
+
+test('cliTeamRosterMembers matches sessionRosterMembers pods', () {
+  final profile = team(const [
+    TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+    TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+    TeamMemberConfig(id: 'reviewer', name: 'Reviewer', replicas: 0),
+  ]);
+  final session = AppSession(
+    sessionId: 's1',
+    workspaceId: 'w1',
+    createdAt: 1,
+    members: const [
+      SessionMemberBinding(rosterMemberId: 'team-lead', taskId: 't0'),
+      SessionMemberBinding(
+        rosterMemberId: 'developer-0',
+        typeId: 'developer',
+        taskId: 't1',
+      ),
+      SessionMemberBinding(
+        rosterMemberId: 'developer-1',
+        typeId: 'developer',
+        taskId: 't2',
+      ),
+    ],
+  );
+  expect(
+    cliTeamRosterMembers(session, profile).map((m) => m.id).toList(),
+    ['team-lead', 'developer-0', 'developer-1'],
+  );
+  expect(
+    cliTeamRosterMembers(session, profile).map((m) => m.agentType).toList(),
+    ['team-lead', 'developer', 'developer'],
+  );
+});
+```
+
+(Import `cliTeamRosterMembers` once Task 2 adds it — either keep this test in Task 2, or stub Task 1 without the `cliTeamRosterMembers` case and move that case to Task 2.)
+
+**Prefer for Task 1 only:** the two `toMemberConfig` agentType tests above. Move `cliTeamRosterMembers` test to Task 2.
+
+- [ ] **Step 2: Run tests — expect FAIL**
+
+```bash
+cd client && flutter test test/models/member_instance_test.dart
+```
+
+Expected: FAIL on `agentType` expectations (today pod keeps empty `agentType`).
+
+- [ ] **Step 3: Implement seed in `toMemberConfig`**
+
+In `member_instance.dart`:
+
+```dart
+TeamMemberConfig toMemberConfig() {
+  final seededAgentType = () {
+    final explicit = type.agentType.trim();
+    if (explicit.isNotEmpty) return explicit;
+    final fromAgent = type.agent.trim();
+    if (fromAgent.isNotEmpty) return fromAgent;
+    return type.id;
+  }();
+  return type.copyWith(
+    id: instanceId,
+    name: displayName,
+    agentType: seededAgentType,
+    capabilities: {type.id, ...type.capabilities},
+    replicas: 1,
+  );
+}
+```
+
+Lead: `type.id == team-lead` → `agentType` becomes `team-lead` (correct).
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cd client && flutter test test/models/member_instance_test.dart
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/lib/models/member_instance.dart client/test/models/member_instance_test.dart
+git commit -m "$(cat <<'EOF'
+fix(roster): seed agentType on pod expansion
+
+Keep Claude agentType as the role/type id when replicas expand to
+developer-0 style pods.
+EOF
+)"
+```
+
+---
+
+### Task 2: Add `cliTeamRosterMembers` (TDD)
+
+**Files:**
+- Modify: `client/lib/models/app_session.dart`
+- Modify: `client/test/models/member_instance_test.dart` (or `app_session` adjacent test)
+
+- [ ] **Step 1: Write failing test**
+
+```dart
+test('cliTeamRosterMembers matches sessionRosterMembers', () {
+  final profile = team(const [
+    TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+    TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+    TeamMemberConfig(id: 'reviewer', name: 'Reviewer', replicas: 0),
+  ]);
+  final session = AppSession(
+    sessionId: 's1',
+    workspaceId: 'w1',
+    createdAt: 1,
+    members: const [
+      SessionMemberBinding(rosterMemberId: 'team-lead', taskId: 't0'),
+      SessionMemberBinding(
+        rosterMemberId: 'developer-0',
+        typeId: 'developer',
+        taskId: 't1',
+      ),
+      SessionMemberBinding(
+        rosterMemberId: 'developer-1',
+        typeId: 'developer',
+        taskId: 't2',
+      ),
+    ],
+  );
+  final cli = cliTeamRosterMembers(session, profile);
+  final ui = sessionRosterMembers(session, profile);
+  expect(cli.map((m) => m.id), ui.map((m) => m.id));
+  expect(cli.map((m) => m.id), ['team-lead', 'developer-0', 'developer-1']);
+  expect(cli.map((m) => m.agentType), ['team-lead', 'developer', 'developer']);
+});
+
+test('singleton replica keeps bare type id', () {
+  final profile = team(const [
+    TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+    TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 1),
+  ]);
+  final session = AppSession(
+    sessionId: 's1',
+    workspaceId: 'w1',
+    createdAt: 1,
+    members: const [
+      SessionMemberBinding(rosterMemberId: 'team-lead', taskId: 't0'),
+      SessionMemberBinding(rosterMemberId: 'developer', taskId: 't1'),
+    ],
+  );
+  expect(
+    cliTeamRosterMembers(session, profile).map((m) => m.id),
+    ['team-lead', 'developer'],
+  );
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL** (undefined `cliTeamRosterMembers`)
+
+```bash
+cd client && flutter test test/models/member_instance_test.dart
+```
+
+- [ ] **Step 3: Implement**
+
+In `app_session.dart`, immediately after `sessionRosterMembers`:
+
+```dart
+/// Pod list for Claude / native CLI roster writers (`config.json`, inboxes).
+///
+/// Same members as [sessionRosterMembers] today. Call sites that stage CLI
+/// team files must use this (or [runtimeRosterMembers] without a session),
+/// never raw [TeamProfile.members].
+List<TeamMemberConfig> cliTeamRosterMembers(
+  AppSession session,
+  TeamProfile team,
+) =>
+    sessionRosterMembers(session, team);
+```
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+cd client && flutter test test/models/member_instance_test.dart
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/lib/models/app_session.dart client/test/models/member_instance_test.dart
+git commit -m "$(cat <<'EOF'
+feat(roster): add cliTeamRosterMembers for CLI staging
+
+Named entry point so launch writers take session pods, not type templates.
+EOF
+)"
+```
+
+---
+
+### Task 3: Claude roster merge uses pods (TDD)
+
+**Files:**
+- Modify: `client/test/services/team/claude_team_roster_service_test.dart`
+- No production change if Task 1+2 done — this locks the contract `mergeConfig` / `ensureInboxes` already satisfy when fed pods.
+
+- [ ] **Step 1: Write tests**
+
+```dart
+test('mergeConfig with pods writes pod names and role agentType', () {
+  final service = ClaudeTeamRosterService(fs: LocalFilesystem());
+  final pods = runtimeRosterMembers(
+    const TeamProfile(
+      id: 'default-native-team',
+      name: 'Default',
+      members: [
+        TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+        TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+        TeamMemberConfig(id: 'reviewer', name: 'Reviewer', replicas: 0),
+      ],
+    ),
+  );
+  final config = service.mergeConfig(
+    cliTeamName: 'default-native-team-5',
+    members: pods,
+    cwd: '/workspace',
+    teammateMode: 'in-process',
+  );
+  final members = (config['members'] as List).cast<Map>();
+  expect(members.map((m) => m['name']), [
+    'team-lead',
+    'developer-0',
+    'developer-1',
+  ]);
+  expect(members.map((m) => m['agentId']), [
+    'team-lead',
+    'developer-0@default-native-team-5',
+    'developer-1@default-native-team-5',
+  ]);
+  final dev0 = members.firstWhere((m) => m['name'] == 'developer-0');
+  expect(dev0['agentType'], 'developer');
+});
+
+test('ensureInboxes creates pod files not type file', () async {
+  final root = Directory.systemTemp.createTempSync('claude-roster-');
+  addTearDown(() => root.deleteSync(recursive: true));
+  final fs = LocalFilesystem();
+  final service = ClaudeTeamRosterService(fs: fs);
+  final rosterDir = p.join(root.path, 'teams', 't');
+  final pods = runtimeRosterMembers(
+    const TeamProfile(
+      id: 't',
+      name: 'T',
+      members: [
+        TeamMemberConfig(id: 'team-lead', name: 'team-lead'),
+        TeamMemberConfig(id: 'developer', name: 'Developer', replicas: 2),
+      ],
+    ),
+  );
+  await service.ensureInboxes(rosterDir: rosterDir, members: pods);
+  expect(File(p.join(rosterDir, 'inboxes', 'developer-0.json')).existsSync(), isTrue);
+  expect(File(p.join(rosterDir, 'inboxes', 'developer-1.json')).existsSync(), isTrue);
+  expect(File(p.join(rosterDir, 'inboxes', 'developer.json')).existsSync(), isFalse);
+});
+```
+
+Use `package:path/path.dart` as `p` (or `fs.pathContext`) consistent with nearby tests.
+
+- [ ] **Step 2: Run**
+
+```bash
+cd client && flutter test test/services/team/claude_team_roster_service_test.dart
+```
+
+Expected: PASS after Task 1 (if FAIL on agentType, Task 1 incomplete).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add client/test/services/team/claude_team_roster_service_test.dart
+git commit -m "$(cat <<'EOF'
+test(roster): lock Claude mergeConfig/inboxes on pod members
+
+EOF
+)"
+```
+
+---
+
+### Task 4: Wire launch staging call sites
+
+**Files:**
+- Modify: `client/lib/services/launch/session_connect_orchestrator.dart` (~line 264: `members: team.members`)
+- Modify: `client/lib/services/session/session_lifecycle_service.dart`
+  - Live seat `prepareTeamLaunch` inside prepareLaunch (~line 844): `cliTeamRosterMembers(session, team)`
+  - Preview `prepareTeamLaunchEnvironment` (~line 416): `runtimeRosterMembers(team)`
+- Test: **extend** `client/test/services/session/session_lifecycle_service_test.dart` (has `prepareLaunch` scaffolding that goes through lifecycle → `prepareTeamLaunch`). Do **not** only assert by calling `prepareTeamLaunch`/`stageTeamLaunch` with a hand-built `members:` list — that bypasses the production call sites and stays green before the wire.
+
+- [ ] **Step 1: Write failing lifecycle tests**
+
+Add to `session_lifecycle_service_test.dart` (mirror existing Claude native `prepareLaunch` setup: temp AppStorage, team profile with replicas, session with pod bindings):
+
+```dart
+test('prepareLaunch writes Claude roster pods not type names', () async {
+  // Team: developer.replicas=2, reviewer.replicas=0
+  // Session.members: team-lead, developer-0, developer-1 (with typeId)
+  final plan = await service().prepareLaunch(/* … same harness as siblings … */);
+  // Locate session Claude teams dir from plan / AppStorage paths used by harness
+  final configPath = /* …/runtime/claude/teams/<cliTeamName>/config.json */;
+  final decoded = jsonDecode(File(configPath).readAsStringSync()) as Map;
+  final names = (decoded['members'] as List)
+      .map((m) => (m as Map)['name'])
+      .toList();
+  expect(names, ['team-lead', 'developer-0', 'developer-1']);
+  final inbox0 = /* …/inboxes/developer-0.json */;
+  expect(File(inbox0).existsSync(), isTrue);
+  expect(File(/* …/inboxes/developer.json */).existsSync(), isFalse);
+});
+
+test('prepareTeamLaunchEnvironment expands runtimeRosterMembers', () async {
+  // Call prepareTeamLaunchEnvironment with developer.replicas=2
+  // Assert written config names include developer-0 / developer-1 (not bare developer only)
+});
+```
+
+Fill concrete paths using the same path helpers / `AppStorage` layout the existing test file already uses for Claude settings assertions (`prepareLaunch writes Claude provider settings…`).
+
+**Red condition:** before Task 4 wiring, `prepareLaunch` still passes `team.members` → config has `developer` / `reviewer` and/or `inboxes/developer.json` → assertion fails.
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd client && flutter test test/services/session/session_lifecycle_service_test.dart --name "Claude roster pods"
+```
+
+(Adjust `--name` to match the test title.)
+
+- [ ] **Step 3: Wire call sites**
+
+`session_connect_orchestrator.dart`:
+
+```dart
+members: cliTeamRosterMembers(session, team),
+```
+
+`session_lifecycle_service.dart` live seat:
+
+```dart
+members: cliTeamRosterMembers(session, team),
+```
+
+`prepareTeamLaunchEnvironment`:
+
+```dart
+members: runtimeRosterMembers(team),
+```
+
+Add imports for `cliTeamRosterMembers` / `runtimeRosterMembers` as needed.
+
+Do **not** change placement / landing settings call sites that still correctly use `team.members`.
+
+Also wire orchestrator even if this task’s automated test only hits lifecycle — keep both production paths consistent (orchestrator is the primary live staging path in the app).
+
+- [ ] **Step 4: Run — expect PASS**
+
+```bash
+cd client && flutter test test/models/member_instance_test.dart \
+  test/services/team/claude_team_roster_service_test.dart \
+  test/services/session/session_lifecycle_service_test.dart
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add client/lib/services/launch/session_connect_orchestrator.dart \
+  client/lib/services/session/session_lifecycle_service.dart \
+  client/test/services/session/session_lifecycle_service_test.dart
+git commit -m "$(cat <<'EOF'
+fix(launch): stage Claude roster from session pods
+
+Stop writing type-level developer/reviewer rows so agent-id and
+inboxes match launched replica shells.
+EOF
+)"
+```
+
+---
+
+### Task 5: Docs + verify
+
+**Files:**
+- Modify: `AGENTS.md` (session roster / CLI section — one short hard-rule sentence)
+
+- [ ] **Step 1: Document hard rule**
+
+Near member placement / session roster guidance, add:
+
+> Native Claude roster writers (`teams/.../config.json`, inboxes) must use `cliTeamRosterMembers(session, team)` when a session exists, or `runtimeRosterMembers(team)` for preview — never raw `team.members`.
+
+- [ ] **Step 2: Analyze + unit tests**
+
+```bash
+cd client && flutter analyze --no-fatal-infos --no-fatal-warnings
+cd client && flutter test test/models/member_instance_test.dart \
+  test/services/team/claude_team_roster_service_test.dart \
+  test/services/session/session_lifecycle_service_test.dart
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add AGENTS.md
+git commit -m "$(cat <<'EOF'
+docs: require pod lists for Claude CLI roster writers
+
+EOF
+)"
+```
+
+---
+
+## Manual acceptance (after implementation)
+
+New native session: `developer.replicas=2`, `reviewer.replicas=0`.
+
+1. Disk roster = `team-lead`, `developer-0`, `developer-1` only; `agentType` for pods = `developer`.
+2. Lead `SendMessage(to: "developer-0")` → `inboxes/developer-0.json`.
+3. `developer-0` process args include `--agent-id developer-0@<cliTeamName>`.
+
+Optional (YAGNI unless easy): debug assert when staging receives bare type ids while session has numbered pods — **skip** unless needed for regression hunting.
+
+---
+
+## Execution handoff
+
+Plan complete. Two options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task, review between tasks  
+2. **Inline Execution** — execute in this session with checkpoints  
+
+Which approach?

--- a/docs/superpowers/specs/2026-08-03-native-cli-roster-pods-design.md
+++ b/docs/superpowers/specs/2026-08-03-native-cli-roster-pods-design.md
@@ -1,0 +1,174 @@
+# Native CLI roster = session pods (design)
+
+**Date:** 2026-08-03  
+**Status:** Approved for planning  
+**Scope:** Align Claude native-team CLI roster identity (`teams/.../config.json`, inboxes, `--agent-id`) with session pods so SendMessage targets the same ids as running shells. Identity alignment only.
+
+## Problem
+
+TeamPilot has two member layers:
+
+| Layer | Source | Example |
+|-------|--------|---------|
+| **Type** (template) | `TeamProfile.roster` / `team.members` | `developer` with `replicas: 2` |
+| **Pod** (runtime instance) | `AppSession.members` → `sessionRosterMembers` | `developer-0`, `developer-1` |
+
+UI, presence, and PTY launch already use **pods**. Native Claude team staging still passes **`team.members` (types)** into `ClaudeTeamRosterService`, which writes:
+
+- `teams/<cliTeamName>/config.json` with `name: developer`, `agentId: developer@…`
+- `inboxes/developer.json`
+
+While shells launch as:
+
+- `--agent-name developer-0 --agent-id developer-0@…`
+
+Lead `SendMessage(to: "developer")` succeeds into `inboxes/developer.json`, but no running process polls that inbox. Replica shells idle forever; `replicas: 0` roles (e.g. reviewer) receive messages with no process at all.
+
+Root cause: **type roster was treated as CLI roster**.
+
+## Goals
+
+1. Single source of truth for “who is in this session’s CLI team”: **session pods**.
+2. Claude `config.json` member `name` / `agentId`, inbox filenames, and CLI `--agent-name` / `--agent-id` all use the **same pod id**.
+3. Native mode keeps supporting `replicas > 1`: each pod is a first-class Claude teammate (no type-name aliasing).
+4. `replicas: 0` (or otherwise absent from `AppSession.members`) does not appear in the CLI roster.
+5. Launch staging paths stop passing `team.members` into Claude roster writers.
+
+## Non-goals
+
+- Type-name SendMessage aliases (`to: "developer"` fan-out or unicast).
+- Idle / inbox wake-up (doorbell, nudge) if Claude already polls a matching inbox.
+- Changing `teammateMode` (in-process vs external PTY) semantics.
+- Mixed-mode TeamBus protocol changes (already pod-based via `sessionRosterMembers`).
+- Redesigning placement UI or type-level roster editing.
+
+## Decisions (locked)
+
+1. **Replicas in native:** supported; each pod is an independent Claude member.
+2. **Addressing:** pure pod ids only; `SendMessage(to: "developer")` failing when only `developer-0`/`developer-1` exist is expected.
+3. **Scope:** identity alignment only.
+
+## Architecture
+
+### Type vs pod (unchanged product model)
+
+- **Type** remains the template: expert, replicas count, placement targets, presets.
+- **Pod** remains the runtime unit: terminal seat, presence, session binding, task id.
+- Editing replicas / experts continues to mutate **type** data (`team.members` / roster overrides).
+
+### CLI roster resolver
+
+Add `cliTeamRosterMembers(AppSession session, TeamProfile team)` next to `sessionRosterMembers` in `client/lib/models/app_session.dart` (or an adjacent small library file if preferred for cycle reasons).
+
+**Behavior for this change:** delegate to `sessionRosterMembers(session, team)`.
+
+**Why a separate name:** call sites express intent (“this list feeds CLI/Claude roster”). UI/presence may keep calling `sessionRosterMembers`. If CLI and UI lists diverge later, only the CLI wrapper changes.
+
+**Invariants:**
+
+- Output member `id` is the pod id (`developer-0`, not `developer` when `replicas > 1`).
+- Singleton types (`replicas <= 1` and a single binding) keep bare type id (`developer`).
+- Lead stays `team-lead` (bare `--agent-id team-lead` rule unchanged).
+- Members not in `session.members` are omitted (covers `replicas: 0` and placement-omitted pods).
+
+### Hard rule
+
+Any path that writes Claude `teams/<cliTeamName>/config.json`, ensures `inboxes/*.json`, or builds native `--agent-name` / `--agent-id` **must** consume one of:
+
+- `cliTeamRosterMembers(session, team)` when an `AppSession` exists, or
+- `runtimeRosterMembers(team)` when staging without a session (preview / environment)
+
+Passing `team.members` into those writers is forbidden.
+
+`--agent-name` / `--agent-id` already derive from the **launched** member config id (`CliLaunchContext.memberCliId`). Fixing the staged roster list is what closes the gap with inbox / config.json.
+
+### Claude roster write behavior
+
+`mergeConfig` / `ensureInboxes` stay keyed by `member.id`. The **input list** must be pods. One related seeding rule is required so `agentType` does not collapse to the pod id:
+
+**`agentType` rule:** For a pod derived from type `developer`, Claude config `agentType` must be the **type/role id** (`developer`), not `developer-0`.
+
+Today `TeamMemberNaming.resolveAgentType` falls back to `member.id` when `agentType`/`agent` are empty. After switching inputs to pods, that fallback would wrongly write `agentType: developer-0`.
+
+**Required small change (not “input-only”):** when expanding Deployment→Pod (`MemberInstance.toMemberConfig`, used by `sessionRosterMembers` / `runtimeRosterMembers`), seed:
+
+- `agentType`: existing non-empty `type.agentType`, else non-empty `type.agent`, else **`type.id`**
+
+So `ClaudeTeamRosterService.buildMemberEntry` can keep calling `resolveAgentType` unchanged and still emit role-level `agentType`.
+
+| Field | Value |
+|-------|--------|
+| `name` | pod id |
+| `agentId` | `TeamMemberNaming.cliAgentId(memberId: podId, cliTeamName: …)` |
+| `agentType` | type/role id (seeded as above), e.g. `developer` for `developer-0` |
+| inbox file | `inboxes/<safe(podId)>.json` |
+
+Each staging pass **rewrites** `config.json` from the current pod list (existing merge preserves `joinedAt` / `isActive` when agentId matches). Type-only rows (e.g. stale `developer`) that are not in the current pod list are **not** re-emitted, so lead does not see ghost teammates.
+
+Stale `inboxes/<type>.json` files from older sessions may remain on disk; **no delete requirement**. New writes create/ensure pod inbox files only.
+
+Member settings files already use launched pod ids (`settings/developer-0.json`); no change required there.
+
+### Call sites to change
+
+**Session launch staging** (have `AppSession`):
+
+1. `client/lib/services/launch/session_connect_orchestrator.dart` → `stageTeamLaunch`
+2. `client/lib/services/session/session_lifecycle_service.dart` → `prepareTeamLaunch` used by live seat connect
+
+Use: `members: cliTeamRosterMembers(session, team)`.
+
+**No-session / preview staging** (e.g. `prepareTeamLaunchEnvironment` → `TeamLaunchService`):
+
+There is no placement-filtered `AppSession`. Use: `members: runtimeRosterMembers(team)` (expand from type `replicas`, same pod id rules).
+
+Never pass `team.members` into Claude roster writers on either path.
+
+### Call sites that stay on types
+
+Placement, landing team settings, and other **template** editors keep using `team.members` / roster overrides. They do not write Claude session `teams/.../config.json` for a live session’s messaging identity.
+
+### Optional guard
+
+Debug-only assert or log when native staging receives a member id that looks like an unreplicated type while the session bindings show numbered pods for that type (detect accidental `team.members` regression).
+
+## Data flow (after)
+
+```
+AppSession.members (bindings)
+  → cliTeamRosterMembers / sessionRosterMembers (pods)
+  → stageTeamLaunch / prepareTeamLaunch (members: pods)
+  → ClaudeTeamRosterService.mergeConfig + ensureInboxes
+  → teams/<cliTeam>/config.json + inboxes/<pod>.json
+
+same pod id
+  → TerminalSession connect
+  → --agent-name <pod> --agent-id <pod>@<cliTeamName> (lead: team-lead)
+```
+
+Lead SendMessage targets pod names from config; messages land in matching inboxes; matching agent processes consume them.
+
+## Testing
+
+1. **Unit — resolver:** `developer.replicas=2`, `reviewer.replicas=0` → pods `team-lead`, `developer-0`, `developer-1`; no `reviewer`; pod configs seed `agentType`/`capabilities` so role id is `developer`.
+2. **Unit — roster merge:** merge with those pods → config names/agentIds are pods; `agentType` is `developer`; no bare `developer` / `reviewer` rows; inboxes ensured for each pod.
+3. **Config / staging:** prepare or stage a native team launch with a session that has numbered developer bindings; assert disk `config.json` and `inboxes/developer-0.json` exist and a type-level `developer.json` is not created for that new write path.
+4. **Unit — singleton:** `replicas=1` keeps bare `developer` id in resolver + merge.
+
+## Acceptance
+
+For a new native session with `developer.replicas=2` and `reviewer.replicas=0`:
+
+1. Claude roster members are `team-lead`, `developer-0`, `developer-1` only.
+2. Config rows for pods use `agentType: developer` (not `developer-0`).
+3. `SendMessage(to: "developer-0")` writes `inboxes/developer-0.json`.
+4. The `developer-0` PTY is launched with `--agent-id developer-0@<cliTeamName>` (same identity as inbox / config).
+
+Also: singleton (`developer.replicas=1`) keeps bare `name`/`agent-name`/`inbox` id `developer` (no `-0` suffix).
+
+## Implementation notes
+
+- Prefer thin wrapper + call-site swap; plus the `agentType` seed on `MemberInstance.toMemberConfig`.
+- Avoid duplicating replica expansion logic.
+- Update AGENTS.md guidance: **CLI native roster writers** must use `cliTeamRosterMembers(session, team)` or, without a session, `runtimeRosterMembers(team)` — never raw `team.members`.
+- Existing sessions with stale type-level `config.json` are healed on next staging rewrite when pods are passed in.


### PR DESCRIPTION
## Summary
- Seed role `agentType` on Deployment→Pod expansion so Claude roster rows keep `developer` when ids become `developer-0`.
- Add `cliTeamRosterMembers` and wire launch staging (`prepareLaunch` / orchestrator / preview) to session pods or `runtimeRosterMembers` instead of raw `team.members`.
- Lock behavior with lifecycle + Claude roster tests; document the hard rule in AGENTS.md.

## Test plan
- [x] `flutter test test/models/member_instance_test.dart test/services/team/claude_team_roster_service_test.dart test/services/session/session_lifecycle_service_test.dart`
- [ ] CI green
- [ ] Manual: native session with `developer.replicas=2`, `reviewer.replicas=0` → disk roster is `team-lead` / `developer-0` / `developer-1` only; inbox files match pods


Made with [Cursor](https://cursor.com)